### PR TITLE
feat(proxy): set headers timeout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -37,8 +37,12 @@ const authMiddleware: (requireAuth: boolean) => express.RequestHandler = (requir
   res.sendStatus(403)
 }
 
-const withKeepAliveTimeout = (server: http.Server, keepAliveTimeout = 620 * 1000) => {
+const withKeepAliveTimeout = (server: http.Server, keepAliveTimeout = 620 * 1000, headersTimeout = 650 * 1000) => {
   server.keepAliveTimeout = keepAliveTimeout
+  // must be bigger than keepAliveTimeout
+  // needed for nodejs > 10.15.2
+  // https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/
+  server.headersTimeout = headersTimeout
 }
 
 const bootstrap = async () => {


### PR DESCRIPTION
This change in made in a hope to resolve occasional magical 502 response from MS graph API.

Might be related to this: https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/